### PR TITLE
feat: Add storage s3 behind CDN

### DIFF
--- a/modules/cloudfront-with-s3-as-public-storage/README.md
+++ b/modules/cloudfront-with-s3-as-public-storage/README.md
@@ -1,0 +1,57 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudfront_cache_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_distribution.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
+| [aws_cloudfront_origin_access_control.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
+| [aws_iam_group.deployment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
+| [aws_iam_group_policy_attachment.deployment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
+| [aws_iam_policy.deployment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [random_id.prefix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_iam_policy_document.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aliases"></a> [aliases](#input\_aliases) | List of CNAMEs | `list(string)` | n/a | yes |
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | Bucket name to create. | `string` | n/a | yes |
+| <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | AWS ACM certificate ARN. | `string` | n/a | yes |
+| <a name="input_certificate_minimum_protocol_version"></a> [certificate\_minimum\_protocol\_version](#input\_certificate\_minimum\_protocol\_version) | The minimum version of the SSL protocol that you want to use for HTTPS. | `string` | `"TLSv1.2_2019"` | no |
+| <a name="input_context"></a> [context](#input\_context) | Project context. | <pre>object({<br>    namespace = string<br>    stage     = string<br>    name      = string<br>  })</pre> | n/a | yes |
+| <a name="input_origin_request_policy_id"></a> [origin\_request\_policy\_id](#input\_origin\_request\_policy\_id) | The identifier for a origin request policy. | `string` | `null` | no |
+| <a name="input_price_class"></a> [price\_class](#input\_price\_class) | Cloudfront distribution's price class. | `string` | `"PriceClass_100"` | no |
+| <a name="input_response_headers_policy_id"></a> [response\_headers\_policy\_id](#input\_response\_headers\_policy\_id) | The identifier for a response headers policy. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags attached to Cloudfront distribution. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | CDN distribution ARN. |
+| <a name="output_deployment_group"></a> [deployment\_group](#output\_deployment\_group) | Deployment group name |
+| <a name="output_deployment_group_arn"></a> [deployment\_group\_arn](#output\_deployment\_group\_arn) | Deployment group ARN |
+| <a name="output_deployment_policy_id"></a> [deployment\_policy\_id](#output\_deployment\_policy\_id) | IAM policy for deploying CloudFront distribution. |
+| <a name="output_domain_name"></a> [domain\_name](#output\_domain\_name) | CDN distribution's domain name. |
+| <a name="output_hosted_zone_id"></a> [hosted\_zone\_id](#output\_hosted\_zone\_id) | CDN Route 53 zone ID. |
+| <a name="output_id"></a> [id](#output\_id) | CDN distribution ID. |
+<!-- END_TF_DOCS -->

--- a/modules/cloudfront-with-s3-as-public-storage/README.md
+++ b/modules/cloudfront-with-s3-as-public-storage/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Resources

--- a/modules/cloudfront-with-s3-as-public-storage/main.tf
+++ b/modules/cloudfront-with-s3-as-public-storage/main.tf
@@ -1,0 +1,181 @@
+locals {
+  origin_id = "main"
+
+  tags = merge({
+    "context.namespace" = var.context.namespace
+    "context.stage"     = var.context.stage
+    "context.name"      = var.context.name
+  }, var.tags)
+}
+
+resource "random_id" "prefix" {
+  byte_length = 4
+}
+
+resource "aws_cloudfront_origin_access_control" "this" {
+  name                              = "cdn-public-storage-${random_id.prefix.hex}"
+  description                       = "Public Storage ${random_id.prefix.hex}"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  comment         = "Public Storage ${random_id.prefix.hex}"
+  enabled         = true
+  is_ipv6_enabled = true
+  aliases         = var.aliases
+  price_class     = var.price_class
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    acm_certificate_arn            = var.certificate_arn
+    minimum_protocol_version       = var.certificate_minimum_protocol_version
+
+    # sni-only is preferred, vip causes CloudFront to use a dedicated IP address and may incur extra charges.
+    ssl_support_method = "sni-only"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  origin {
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-origin.html
+    domain_name              = aws_s3_bucket.this.bucket_regional_domain_name
+    origin_id                = local.origin_id # must be unique within distribution
+    origin_access_control_id = aws_cloudfront_origin_access_control.this.id
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.origin_id
+
+    response_headers_policy_id = var.response_headers_policy_id
+    origin_request_policy_id   = var.origin_request_policy_id
+    cache_policy_id            = aws_cloudfront_cache_policy.this.id
+    compress                   = true
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  tags = merge(local.tags, { "resource.group" = "network" })
+}
+
+resource "aws_iam_policy" "deployment_policy" {
+  name   = "cdn-deployment-public-storage-${random_id.prefix.hex}"
+  policy = data.aws_iam_policy_document.this.json
+}
+
+data "aws_iam_policy_document" "this" {
+  version = "2012-10-17"
+
+  statement {
+    sid = 1
+
+    actions = [
+      "cloudfront:CreateInvalidation",
+    ]
+
+    resources = [
+      aws_cloudfront_distribution.this.arn
+    ]
+  }
+
+  statement {
+    sid = 2
+    actions = [
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.this.arn}/*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = [
+      aws_s3_bucket.this.arn
+    ]
+  }
+}
+
+resource "aws_iam_group" "deployment" {
+  name = "cdn-deployment-public-storage-${random_id.prefix.hex}"
+}
+
+resource "aws_iam_group_policy_attachment" "deployment" {
+  group      = aws_iam_group.deployment.name
+  policy_arn = aws_iam_policy.deployment_policy.arn
+}
+
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  policy = data.aws_iam_policy_document.bucket.json
+}
+
+data "aws_iam_policy_document" "bucket" {
+  statement {
+    sid    = "AllowCloudFrontServicePrincipalReadOnly"
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.bucket}/*"
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+
+      values = [
+        aws_cloudfront_distribution.this.arn
+      ]
+    }
+  }
+}
+
+resource "aws_cloudfront_cache_policy" "this" {
+  name    = "cdn-public-storage-${random_id.prefix.hex}"
+  comment = "Cache policy for Public Storage ${random_id.prefix.hex}"
+
+  min_ttl     = 1
+  default_ttl = 86400
+  max_ttl     = 31536000
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+  }
+}

--- a/modules/cloudfront-with-s3-as-public-storage/outputs.tf
+++ b/modules/cloudfront-with-s3-as-public-storage/outputs.tf
@@ -1,0 +1,34 @@
+output "id" {
+  value       = aws_cloudfront_distribution.this.id
+  description = "CDN distribution ID."
+}
+
+output "arn" {
+  value       = aws_cloudfront_distribution.this.arn
+  description = "CDN distribution ARN."
+}
+
+output "domain_name" {
+  value       = aws_cloudfront_distribution.this.domain_name
+  description = "CDN distribution's domain name."
+}
+
+output "hosted_zone_id" {
+  value       = aws_cloudfront_distribution.this.hosted_zone_id
+  description = "CDN Route 53 zone ID."
+}
+
+output "deployment_policy_id" {
+  value       = aws_iam_policy.deployment_policy.arn
+  description = "IAM policy for deploying CloudFront distribution."
+}
+
+output "deployment_group" {
+  value       = aws_iam_group.deployment.name
+  description = "Deployment group name"
+}
+
+output "deployment_group_arn" {
+  value       = aws_iam_group.deployment.arn
+  description = "Deployment group ARN"
+}

--- a/modules/cloudfront-with-s3-as-public-storage/variables.tf
+++ b/modules/cloudfront-with-s3-as-public-storage/variables.tf
@@ -1,0 +1,59 @@
+# required
+
+variable "context" {
+  description = "Project context."
+
+  type = object({
+    namespace = string
+    stage     = string
+    name      = string
+  })
+}
+
+variable "aliases" {
+  type        = list(string)
+  description = "List of CNAMEs"
+}
+
+variable "certificate_arn" {
+  type        = string
+  description = "AWS ACM certificate ARN."
+}
+
+variable "bucket" {
+  type        = string
+  description = "Bucket name to create."
+}
+
+# optional
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags attached to Cloudfront distribution."
+  default     = {}
+}
+
+variable "certificate_minimum_protocol_version" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#minimum_protocol_version
+  type        = string
+  default     = "TLSv1.2_2019"
+  description = "The minimum version of the SSL protocol that you want to use for HTTPS."
+}
+
+variable "response_headers_policy_id" {
+  type        = string
+  description = "The identifier for a response headers policy."
+  default     = null
+}
+
+variable "origin_request_policy_id" {
+  type        = string
+  description = "The identifier for a origin request policy."
+  default     = null
+}
+
+variable "price_class" {
+  type        = string
+  description = "Cloudfront distribution's price class."
+  default     = "PriceClass_100"
+}

--- a/modules/cloudfront-with-s3-as-public-storage/versions.tf
+++ b/modules/cloudfront-with-s3-as-public-storage/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
This adds S3 (private) and CDN that is configured to serve assets from s3 publicly.