### PR TITLE
feat: rds storage type gp3

### DIFF
--- a/modules/cloudfront-with-s3-as-public-storage/README.md
+++ b/modules/cloudfront-with-s3-as-public-storage/README.md
@@ -48,6 +48,7 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | CDN distribution ARN. |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of the storage S3 bucket. |
 | <a name="output_deployment_group"></a> [deployment\_group](#output\_deployment\_group) | Deployment group name |
 | <a name="output_deployment_group_arn"></a> [deployment\_group\_arn](#output\_deployment\_group\_arn) | Deployment group ARN |
 | <a name="output_deployment_policy_id"></a> [deployment\_policy\_id](#output\_deployment\_policy\_id) | IAM policy for deploying CloudFront distribution. |

--- a/modules/ecs-service/README.md
+++ b/modules/ecs-service/README.md
@@ -85,5 +85,7 @@
 | <a name="output_name"></a> [name](#output\_name) | Service name. |
 | <a name="output_service_id"></a> [service\_id](#output\_service\_id) | ARN that identifies the service. |
 | <a name="output_task_execution_role_id"></a> [task\_execution\_role\_id](#output\_task\_execution\_role\_id) | ECS task execution role ID |
+| <a name="output_task_one_off_template"></a> [task\_one\_off\_template](#output\_task\_one\_off\_template) | Task json template for one-off commands |
 | <a name="output_task_role_id"></a> [task\_role\_id](#output\_task\_role\_id) | ECS task role ID |
+| <a name="output_task_template"></a> [task\_template](#output\_task\_template) | Task json template for service |
 <!-- END_TF_DOCS -->

--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -43,6 +43,7 @@
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Postgres version. | `string` | n/a | yes |
 | <a name="input_identifier"></a> [identifier](#input\_identifier) | RDS identifier. | `string` | n/a | yes |
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | Instance class. | `string` | `"db.t4g.micro"` | no |
+| <a name="input_iops"></a> [iops](#input\_iops) | The amount of provisioned IOPS. Setting this is only valid for storage\_type gp3, io1, or io2. | `number` | `null` | no |
 | <a name="input_logs_retention_in_days"></a> [logs\_retention\_in\_days](#input\_logs\_retention\_in\_days) | Postgres and upgrade logs retention counted in days. | `number` | `60` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | Maintenance window | `string` | `"Mon:00:00-Mon:02:00"` | no |
 | <a name="input_max_allocated_storage"></a> [max\_allocated\_storage](#input\_max\_allocated\_storage) | Max allocated storage size (GiB) | `number` | `100` | no |
@@ -54,6 +55,8 @@
 | <a name="input_port"></a> [port](#input\_port) | Database port | `number` | `5432` | no |
 | <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | DB publicly accessible | `bool` | `false` | no |
 | <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Snapshot identifier to restore from. | `string` | `null` | no |
+| <a name="input_storage_throughput"></a> [storage\_throughput](#input\_storage\_throughput) | Storage throughput (in MiBps) to be configured on the RDS instance. Only valid for gp3. | `number` | `null` | no |
+| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | The type of storage to use (e.g., gp2, gp3, io1). | `string` | `"gp3"` | no |
 | <a name="input_vpc"></a> [vpc](#input\_vpc) | VPC configuration (id, CIDR that has access to RDS and subnet). | <pre>object({<br>    id           = string<br>    cidr         = string<br>    subnet_group = string<br>  })</pre> | n/a | yes |
 
 ## Outputs

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -75,6 +75,7 @@ resource "aws_db_instance" "this" {
   engine_version = var.engine_version
 
   instance_class        = var.instance_class
+  storage_type          = var.storage_type
   allocated_storage     = var.allocated_storage
   max_allocated_storage = var.max_allocated_storage
   storage_encrypted     = true

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -160,3 +160,21 @@ variable "parameters" {
   description = "Configuration for parameters group"
   default     = {}
 }
+
+variable "storage_type" {
+  description = "The type of storage to use (e.g., gp2, gp3, io1)."
+  type        = string
+  default     = "gp3"
+}
+
+variable "iops" {
+  description = "The amount of provisioned IOPS. Setting this is only valid for storage_type gp3, io1, or io2."
+  type        = number
+  default     = null # For gp3, AWS defaults to 3000 IOPS if null
+}
+
+variable "storage_throughput" {
+  description = "Storage throughput (in MiBps) to be configured on the RDS instance. Only valid for gp3."
+  type        = number
+  default     = null # For gp3, AWS defaults to 125 MiB/s if null
+}


### PR DESCRIPTION
Add support for gp3 storage type

- Added storage_type, iops, and storage_throughput variables to RDS module.
- Set gp3 as the new default storage type for better cost-efficiency and performance.
- Updated aws_db_instance resource to support independent IOPS and throughput scaling.